### PR TITLE
Disable webgems.io in footer

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -28,7 +28,7 @@ footer
       li
         a(href="https://github.com/devcord/devmod") devmod
       li
-        a(href="https://webgems.io/") Webgems
+        //- a(href="https://webgems.io/") Webgems
       li
         //- a( to="https://sysgems.io/" ) Sysgems
       li


### PR DESCRIPTION
Disable webgems.io URL in footer since webpage is no longer active.